### PR TITLE
Blocked access to edit members page from non-Admins who type in page url

### DIFF
--- a/angular/src/app/edit-members/edit-members.component.ts
+++ b/angular/src/app/edit-members/edit-members.component.ts
@@ -21,12 +21,24 @@ export class EditMembersComponent implements OnInit {
 
   private memberClicked: Member;
   private userId: string;
+  private userRole: string;
 
   constructor(private toastr: ToastrService, private auth: AuthService, private router: Router, private memberService: MemberService, private sharedService: SharedService) {
 
     if(this.auth.loggedIn()) {
       var currentUserId = this.auth.getCurrentUserId();
       this.userId = currentUserId;
+      this.memberService.getMemberById(this.userId).subscribe(res => {
+        var member = res as Member;
+        this.userRole = member.role;
+      })
+    } else {
+      this.userRole = '';
+    }
+
+    if(this.userRole != 'admin') {
+      alert('You do not have permission to access this page');
+      this.router.navigate(['home']);
     }
 
   }

--- a/angular/src/app/edit-members/edit-members.component.ts
+++ b/angular/src/app/edit-members/edit-members.component.ts
@@ -21,7 +21,7 @@ export class EditMembersComponent implements OnInit {
 
   private memberClicked: Member;
   private userId: string;
-  private userRole: string;
+  private userRole: string = '';
 
   constructor(private toastr: ToastrService, private auth: AuthService, private router: Router, private memberService: MemberService, private sharedService: SharedService) {
 
@@ -31,16 +31,13 @@ export class EditMembersComponent implements OnInit {
       this.memberService.getMemberById(this.userId).subscribe(res => {
         var member = res as Member;
         this.userRole = member.role;
-      })
-    } else {
-      this.userRole = '';
+        if(this.userRole != 'admin') {
+          alert('You do not have permission to access this page');
+          console.log(this.userRole)
+          this.router.navigate(['home']);
+        }
+      });
     }
-
-    if(this.userRole != 'admin') {
-      alert('You do not have permission to access this page');
-      this.router.navigate(['home']);
-    }
-
   }
 
   ngOnInit() {

--- a/angular/src/app/edit-members/edit-members.component.ts
+++ b/angular/src/app/edit-members/edit-members.component.ts
@@ -33,11 +33,11 @@ export class EditMembersComponent implements OnInit {
         this.userRole = member.role;
         if(this.userRole != 'admin') {
           alert('You do not have permission to access this page');
-          console.log(this.userRole)
           this.router.navigate(['home']);
         }
       });
     }
+    
   }
 
   ngOnInit() {


### PR DESCRIPTION
As the site currently stands, users can circumvent the website to access Admin features despite not having the admin role themselves. This can by done by just typing in the URL to the page containing the admin features, such as editing members, which would then give them full access to anything an admin would be able to do. With these changes, it checks the user's role on page load and sends an alert saying you're not allowed to access this page and redirects them to the home page, before ever getting to even see the page.